### PR TITLE
Feature/11737 add api key on auth header

### DIFF
--- a/src/AbstractApiClient.php
+++ b/src/AbstractApiClient.php
@@ -330,9 +330,7 @@ abstract class AbstractApiClient implements ApiClientInterface
     public function send(RequestDescriptor $request, $flags = 0)
     {
         if(!empty($this->getAuthorization())) {
-            $request->setHeaders([
-                'Authorization' => $this->getAuthorization()
-            ]);
+            $request->addHeader('Autorization', $this->getAuthorization());
         }
 
         if ($this->delayNext || $this->isDelayed) {

--- a/src/AbstractApiClient.php
+++ b/src/AbstractApiClient.php
@@ -22,6 +22,16 @@ abstract class AbstractApiClient implements ApiClientInterface
     const OPTION_BASEURL = 'baseUrl';
 
     /**
+     * add api key on this header
+     */
+    const OPTION_HEADER_AUTHORISATION = 'Authorization';
+
+    /**
+     * @var string
+     */
+    protected $authorization;
+
+    /**
      * @var string
      */
     protected $baseUrl;
@@ -319,6 +329,12 @@ abstract class AbstractApiClient implements ApiClientInterface
      */
     public function send(RequestDescriptor $request, $flags = 0)
     {
+        if(!empty($this->getAuthorization())) {
+            $request->setHeaders([
+                'Authorization' => $this->getAuthorization()
+            ]);
+        }
+
         if ($this->delayNext || $this->isDelayed) {
             if (!$this->forceNext) {
                 $this->delayedRequests[] = array($request, $flags | ApiRequestOption::NO_RESPONSE);
@@ -479,6 +495,25 @@ abstract class AbstractApiClient implements ApiClientInterface
     public function resetFallbackTransport()
     {
         $this->fallbackTransport = null;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getAuthorization()
+    {
+        return $this->authorization;
+    }
+
+    /**
+     * @param string $authorization
+     * @return AbstractApiClient
+     */
+    public function setAuthorization($authorization)
+    {
+        $this->authorization = $authorization;
 
         return $this;
     }

--- a/src/AbstractApiClient.php
+++ b/src/AbstractApiClient.php
@@ -24,7 +24,7 @@ abstract class AbstractApiClient implements ApiClientInterface
     /**
      * add api key on this header
      */
-    const OPTION_HEADER_AUTHORISATION = 'authorization';
+    const OPTION_HEADER_AUTHORISATION = 'Authorization';
 
     /**
      * @var string
@@ -329,8 +329,8 @@ abstract class AbstractApiClient implements ApiClientInterface
      */
     public function send(RequestDescriptor $request, $flags = 0)
     {
-        if(!empty($this->getAuthorization())) {
-            $request->addHeader('Autorization', $this->getAuthorization());
+        if (!empty($this->getAuthorization())) {
+            $request->addHeader(self::OPTION_HEADER_AUTHORISATION, $this->getAuthorization());
         }
 
         if ($this->delayNext || $this->isDelayed) {

--- a/src/AbstractApiClient.php
+++ b/src/AbstractApiClient.php
@@ -24,7 +24,7 @@ abstract class AbstractApiClient implements ApiClientInterface
     /**
      * add api key on this header
      */
-    const OPTION_HEADER_AUTHORISATION = 'Authorization';
+    const OPTION_HEADER_AUTHORISATION = 'authorization';
 
     /**
      * @var string

--- a/tests/unit/AbstractClientTest.php
+++ b/tests/unit/AbstractClientTest.php
@@ -310,21 +310,29 @@ class ClientTest extends Unit
 
     public function testOptionsHandling()
     {
+        $optionsValue = [
+            AbstractApiClient::OPTION_BASEURL              => 'http://base-url.com',
+            AbstractApiClient::OPTION_HEADER_AUTHORISATION => 'authorizationHeaderValue'
+        ];
         /** @var AbstractApiClient $client */
-        $client = $this->getMockForAbstractClass(AbstractApiClient::class, [[AbstractApiClient::OPTION_BASEURL => 'http://base-url.com']], '', true, true, true, ['commit']);
+        $client = $this->getMockForAbstractClass(AbstractApiClient::class, [$optionsValue], '', true, true, true, ['commit']);
 
         $this->assertAttributeEquals('http://base-url.com/', 'baseUrl', $client);
         $this->assertEquals('http://base-url.com/', $client->getBaseUrl());
         $this->assertEquals('http://base-url.com/', $client->getOption(AbstractApiClient::OPTION_BASEURL));
+
+        $this->assertAttributeEquals('authorizationHeaderValue', 'authorization', $client);
+        $this->assertEquals('authorizationHeaderValue', $client->getAuthorization());
+        $this->assertEquals('authorizationHeaderValue', $client->getOption(AbstractApiClient::OPTION_HEADER_AUTHORISATION));
     }
 
     public function testOptionsInitialization()
     {
         $client = $this->getMockForAbstractClass(AbstractApiClient::class, [[AbstractApiClient::OPTION_BASEURL => 'http://base-url.com']], '', true, true, true, ['commit']);
-        $this->assertAttributeEquals(['baseUrl'], 'availableOptions', $client);
+        $this->assertAttributeEquals(['baseUrl', 'authorization'], 'availableOptions', $client);
 
         $client = new TestClient();
-        $this->assertAttributeEquals(['testOption', 'baseUrl'], 'availableOptions', $client);
+        $this->assertAttributeEquals(['testOption', 'baseUrl', 'authorization'], 'availableOptions', $client);
     }
 
     public function testSettingUnknownOptionThrowsAnException()

--- a/tests/unit/AbstractClientTest.php
+++ b/tests/unit/AbstractClientTest.php
@@ -329,10 +329,10 @@ class ClientTest extends Unit
     public function testOptionsInitialization()
     {
         $client = $this->getMockForAbstractClass(AbstractApiClient::class, [[AbstractApiClient::OPTION_BASEURL => 'http://base-url.com']], '', true, true, true, ['commit']);
-        $this->assertAttributeEquals(['baseUrl', 'authorization'], 'availableOptions', $client);
+        $this->assertAttributeEquals(['baseUrl', 'Authorization'], 'availableOptions', $client);
 
         $client = new TestClient();
-        $this->assertAttributeEquals(['testOption', 'baseUrl', 'authorization'], 'availableOptions', $client);
+        $this->assertAttributeEquals(['testOption', 'baseUrl', 'Authorization'], 'availableOptions', $client);
     }
 
     public function testSettingUnknownOptionThrowsAnException()


### PR DESCRIPTION
- add option 'authorization' to add header 'Authorization' with a value on each request send 
(to use an apiKey for https://github.com/yoctu/api-guardian in all fei Api client )